### PR TITLE
Fix iOS SDK settings and gesture events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set_target_properties(FinalStorm-iOS PROPERTIES
     XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
     XCODE_ATTRIBUTE_SDKROOT "iphoneos"
     XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "iphonesimulator iphoneos"
+    XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS "$(inherited)"
 )
 
 target_include_directories(FinalStorm-iOS PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/MetalRenderer/MetalRenderer.h
+++ b/MetalRenderer/MetalRenderer.h
@@ -1,6 +1,14 @@
 #import <Metal/Metal.h>
 #import <MetalKit/MetalKit.h>
 #import <simd/simd.h>
+#import <TargetConditionals.h>
+#if TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+typedef NSPoint FSPoint;
+#else
+#import <UIKit/UIKit.h>
+typedef CGPoint FSPoint;
+#endif
 
 #include "../Shared/Core/Math/Math.h"
 #include "../Shared/Core/World/WorldManager.h"
@@ -10,9 +18,9 @@
 
 - (nonnull instancetype)initWithMetalKitView:(nonnull MTKView *)mtkView;
 - (void)updateWithDeltaTime:(float)deltaTime;
-- (void)handleMouseDown:(NSPoint)point;
-- (void)handleMouseDragged:(NSPoint)point;
-- (void)handleMouseUp:(NSPoint)point;
+- (void)handleMouseDown:(FSPoint)point;
+- (void)handleMouseDragged:(FSPoint)point;
+- (void)handleMouseUp:(FSPoint)point;
 - (void)handleKeyDown:(uint16_t)keyCode;
 - (void)handleKeyUp:(uint16_t)keyCode;
 

--- a/MetalRenderer/MetalRenderer.mm
+++ b/MetalRenderer/MetalRenderer.mm
@@ -36,7 +36,7 @@ using namespace FinalStorm;
     std::shared_ptr<Camera> _camera;
     
     // Input state
-    NSPoint _lastMousePosition;
+    FSPoint _lastMousePosition;
     bool _mouseDown;
     std::unordered_set<uint16_t> _keysPressed;
 }
@@ -332,13 +332,13 @@ using namespace FinalStorm;
 
 #pragma mark - Input Handling
 
-- (void)handleMouseDown:(NSPoint)point
+- (void)handleMouseDown:(FSPoint)point
 {
    _mouseDown = true;
    _lastMousePosition = point;
 }
 
-- (void)handleMouseDragged:(NSPoint)point
+- (void)handleMouseDragged:(FSPoint)point
 {
    if (_mouseDown)
    {
@@ -367,7 +367,7 @@ using namespace FinalStorm;
    }
 }
 
-- (void)handleMouseUp:(NSPoint)point
+- (void)handleMouseUp:(FSPoint)point
 {
    _mouseDown = false;
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ To generate the Xcode project run:
 This script creates a `build` directory and produces `FinalStorm.xcodeproj`.
 Open the project in Xcode to build and run the client.
 
+When opening the generated project, ensure the **FinalStorm-iOS** target
+uses the iOS SDK. In Xcode's Build Settings, the **Base SDK** should be
+either *iPhoneOS* or *iPhoneSimulator*. If you see build errors such as
+`CVOpenGLESTexture.h` not found, the macOS SDK is selected by mistake.
+Adjust the SDK and verify the framework search paths do not reference
+`MacOSX.platform`.
+
 For a bare CMake invocation you can also run:
 
 ```bash

--- a/iOS/GameViewController.mm
+++ b/iOS/GameViewController.mm
@@ -94,9 +94,24 @@
 
 - (void)handlePan:(UIPanGestureRecognizer *)gesture
 {
-    CGPoint translation = [gesture translationInView:self.view];
-    // Convert to Metal coordinates and pass to renderer
-    [_renderer handleMouseDragged:NSMakePoint(translation.x, translation.y)];
+    CGPoint location = [gesture locationInView:self.view];
+    FSPoint point = CGPointMake(location.x, location.y);
+
+    switch (gesture.state) {
+        case UIGestureRecognizerStateBegan:
+            [_renderer handleMouseDown:point];
+            break;
+        case UIGestureRecognizerStateChanged:
+            [_renderer handleMouseDragged:point];
+            break;
+        case UIGestureRecognizerStateEnded:
+        case UIGestureRecognizerStateCancelled:
+            [_renderer handleMouseUp:point];
+            break;
+        default:
+            break;
+    }
+
     [gesture setTranslation:CGPointZero inView:self.view];
 }
 

--- a/macOS/AppDelegate.h
+++ b/macOS/AppDelegate.h
@@ -9,6 +9,8 @@
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
 
+@property (strong) NSWindow *window;
+
 
 @end
 

--- a/macOS/AppDelegate.m
+++ b/macOS/AppDelegate.m
@@ -6,6 +6,7 @@
 //
 
 #import "AppDelegate.h"
+#import "GameViewController.h"
 
 @interface AppDelegate ()
 
@@ -14,7 +15,18 @@
 @implementation AppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
-    // Insert code here to initialize your application
+    NSRect frame = NSMakeRect(0, 0, 800, 600);
+    NSUInteger style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+                        NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable;
+    self.window = [[NSWindow alloc] initWithContentRect:frame
+                                              styleMask:style
+                                                backing:NSBackingStoreBuffered
+                                                  defer:NO];
+    self.window.title = @"FinalStorm";
+
+    GameViewController *vc = [[GameViewController alloc] initWithNibName:nil bundle:nil];
+    self.window.contentViewController = vc;
+    [self.window makeKeyAndOrderFront:nil];
 }
 
 


### PR DESCRIPTION
## Summary
- use inherited framework search paths for iOS target
- update iOS pan gesture to send mouse down/up events
- document how to select the iOS SDK in Xcode

## Testing
- `./verify_structure.sh`
- `./generate_xcodeproj.sh` *(fails: Could not create named generator Xcode)*

------
https://chatgpt.com/codex/tasks/task_e_685039f2448883328e405fccf127acbd