### PR TITLE
Fix macOS and iOS build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(FinalStorm MACOSX_BUNDLE
     ${SHARED_SOURCES}
     ${METAL_RENDERER_SOURCES}
     macOS/main.m
+    macOS/AppDelegate.m
     macOS/GameViewController.mm
     ${METAL_SHADERS}
 )
@@ -106,13 +107,13 @@ target_include_directories(FinalStorm-iOS PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Link iOS frameworks explicitly
 target_link_libraries(FinalStorm-iOS
-    "-framework" Metal
-    "-framework" MetalKit
-    "-framework" QuartzCore
-    "-framework" CoreFoundation
-    "-framework" Foundation
-    "-framework" CoreGraphics
-    "-framework" UIKit
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework QuartzCore"
+    "-framework CoreFoundation"
+    "-framework Foundation"
+    "-framework CoreGraphics"
+    "-framework UIKit"
 )
 
 # Shader compilation for iOS


### PR DESCRIPTION
## Summary
- include AppDelegate in macOS build to resolve missing symbol error
- link iOS frameworks correctly so Metal framework is found

## Testing
- `./verify_structure.sh`
- `cmake ..` *(fails: Could not find METAL_FRAMEWORK)*

------
https://chatgpt.com/codex/tasks/task_e_68505dfaf2c083329cd51725c6637cb7