### PR TITLE
Add scene graph and MetalRenderer passes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SHARED_SOURCES
     Shared/Core/Networking/FinalverseClient.cpp
     Shared/Core/Networking/MessageProtocol.cpp
     Shared/Core/Audio/AudioEngine.cpp
+    Shared/SceneGraph/SceneNode.cpp
+    Shared/SceneGraph/ServiceNode.cpp
 )
 
 set(METAL_RENDERER_SOURCES

--- a/MetalRenderer/MetalRenderer.h
+++ b/MetalRenderer/MetalRenderer.h
@@ -12,6 +12,7 @@ typedef CGPoint FSPoint;
 
 #include "../Shared/Core/Math/Math.h"
 #include "../Shared/Core/World/WorldManager.h"
+#include "../Shared/SceneGraph/SceneNode.h"
 #include <memory>
 
 @interface MetalRenderer : NSObject<MTKViewDelegate>
@@ -24,7 +25,15 @@ typedef CGPoint FSPoint;
 - (void)handleKeyDown:(uint16_t)keyCode;
 - (void)handleKeyUp:(uint16_t)keyCode;
 
+// Rendering passes
+- (void)renderShadowPassWithCommandBuffer:(id<MTLCommandBuffer>)commandBuffer;
+- (void)renderMainPassWithCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+                 renderPassDescriptor:(MTLRenderPassDescriptor*)renderPassDescriptor;
+- (void)renderPostProcessWithCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+                     renderPassDescriptor:(MTLRenderPassDescriptor*)renderPassDescriptor;
+
 @property (nonatomic, readonly) std::shared_ptr<FinalStorm::WorldManager> worldManager;
 @property (nonatomic, readonly) std::shared_ptr<FinalStorm::Camera> camera;
+@property (nonatomic, readonly) std::shared_ptr<FinalStorm::SceneNode> sceneRoot;
 
 @end

--- a/Shared/SceneGraph/SceneNode.cpp
+++ b/Shared/SceneGraph/SceneNode.cpp
@@ -1,0 +1,156 @@
+#include "SceneNode.h"
+#include "../Renderer/Renderer.h"
+#include <algorithm>
+
+namespace FinalStorm {
+
+namespace {
+static float4 quatMultiply(const float4& a, const float4& b)
+{
+    return make_float4(
+        a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
+        a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
+        a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
+        a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z
+    );
+}
+}
+
+SceneNode::SceneNode()
+    : m_position(make_float3(0.0f)),
+      m_rotation(make_float4(0.0f,0.0f,0.0f,1.0f)),
+      m_scale(make_float3(1.0f)),
+      m_dirty(true),
+      m_visible(true)
+{
+    m_worldMatrix = matrix_identity();
+}
+
+void SceneNode::setPosition(const float3& pos)
+{
+    m_position = pos;
+    markDirty();
+}
+
+void SceneNode::setRotation(const float4& rot)
+{
+    m_rotation = rot;
+    markDirty();
+}
+
+void SceneNode::setScale(const float3& s)
+{
+    m_scale = s;
+    markDirty();
+}
+
+void SceneNode::translate(const float3& delta)
+{
+    m_position += delta;
+    markDirty();
+}
+
+void SceneNode::rotate(const float4& quat)
+{
+    m_rotation = quatMultiply(quat, m_rotation);
+    markDirty();
+}
+
+void SceneNode::addChild(NodePtr child)
+{
+    if (!child || child.get() == this) return;
+    child->m_parent = shared_from_this();
+    child->markDirty();
+    m_children.push_back(child);
+}
+
+void SceneNode::removeChild(NodePtr child)
+{
+    auto it = std::find(m_children.begin(), m_children.end(), child);
+    if (it != m_children.end()) {
+        (*it)->m_parent.reset();
+        m_children.erase(it);
+    }
+}
+
+void SceneNode::clearChildren()
+{
+    for (auto& c : m_children) {
+        if (c) c->m_parent.reset();
+    }
+    m_children.clear();
+}
+
+float4x4 SceneNode::getWorldMatrix() const
+{
+    if (m_dirty)
+        updateWorldTransform();
+    return m_worldMatrix;
+}
+
+float3 SceneNode::getWorldPosition() const
+{
+    float4x4 m = getWorldMatrix();
+    return make_float3(m.columns[3].x, m.columns[3].y, m.columns[3].z);
+}
+
+void SceneNode::updateWorldTransform() const
+{
+    float4x4 local = simd_mul(simd_mul(matrix_translation(m_position),
+                                       matrix_rotation(m_rotation)),
+                               matrix_scale(m_scale));
+    if (auto p = m_parent.lock()) {
+        m_worldMatrix = simd_mul(p->getWorldMatrix(), local);
+    } else {
+        m_worldMatrix = local;
+    }
+    m_dirty = false;
+}
+
+void SceneNode::markDirty()
+{
+    m_dirty = true;
+    for (auto& child : m_children) {
+        if (child)
+            child->markDirty();
+    }
+}
+
+void SceneNode::update(float deltaTime)
+{
+    (void)deltaTime;
+    if (m_entity) {
+        const Transform& t = m_entity->getTransform();
+        m_position = t.position;
+        m_rotation = t.rotation;
+        m_scale = t.scale;
+        markDirty();
+    }
+
+    onUpdate(deltaTime);
+
+    for (auto& child : m_children) {
+        if (child)
+            child->update(deltaTime);
+    }
+}
+
+void SceneNode::render(Renderer* renderer)
+{
+    if (!m_visible) return;
+
+    updateWorldTransform();
+
+    if (renderer && m_entity && m_entity->isVisible()) {
+        renderer->drawMesh(m_entity->getMeshName(), m_worldMatrix);
+    }
+
+    onRender(renderer);
+
+    for (auto& child : m_children) {
+        if (child)
+            child->render(renderer);
+    }
+}
+
+} // namespace FinalStorm

--- a/Shared/SceneGraph/SceneNode.h
+++ b/Shared/SceneGraph/SceneNode.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "../Core/Math/Math.h"
+#include "../Core/Math/Transform.h"
+#include "../Core/World/Entity.h"
+#include <memory>
+#include <vector>
+
+namespace FinalStorm {
+
+class Renderer; // forward declaration
+
+// Basic scene graph node with transform hierarchy
+class SceneNode : public std::enable_shared_from_this<SceneNode> {
+public:
+    using NodePtr = std::shared_ptr<SceneNode>;
+    using NodeList = std::vector<NodePtr>;
+
+    SceneNode();
+    virtual ~SceneNode() = default;
+
+    // Transform operations
+    void setPosition(const float3& pos);
+    void setRotation(const float4& rot);
+    void setScale(const float3& s);
+    void translate(const float3& delta);
+    void rotate(const float4& quat);
+
+    // Hierarchy management
+    void addChild(NodePtr child);
+    void removeChild(NodePtr child);
+    void clearChildren();
+    const NodeList& getChildren() const { return m_children; }
+
+    SceneNode* getParent() const { return m_parent.lock().get(); }
+
+    // World transform helpers
+    float4x4 getWorldMatrix() const;
+    float3 getWorldPosition() const;
+
+    // Entity attachment
+    void setEntity(EntityPtr entity) { m_entity = entity; }
+    EntityPtr getEntity() const { return m_entity; }
+
+    bool isVisible() const { return m_visible; }
+    void setVisible(bool v) { m_visible = v; }
+
+    // Update and render
+    virtual void update(float deltaTime);
+    virtual void render(Renderer* renderer);
+
+protected:
+    virtual void onUpdate(float deltaTime) {}
+    virtual void onRender(Renderer* renderer) {}
+
+    void markDirty();
+    void updateWorldTransform() const;
+
+    std::weak_ptr<SceneNode> m_parent;
+    NodeList m_children;
+
+    float3 m_position;
+    float4 m_rotation;
+    float3 m_scale;
+
+    mutable float4x4 m_worldMatrix;
+    mutable bool m_dirty;
+    bool m_visible;
+
+    EntityPtr m_entity;
+};
+
+} // namespace FinalStorm

--- a/Shared/SceneGraph/ServiceNode.cpp
+++ b/Shared/SceneGraph/ServiceNode.cpp
@@ -1,0 +1,5 @@
+#include "ServiceNode.h"
+
+namespace FinalStorm {
+
+} // namespace FinalStorm

--- a/Shared/SceneGraph/ServiceNode.h
+++ b/Shared/SceneGraph/ServiceNode.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "SceneNode.h"
+
+namespace FinalStorm {
+
+// Simple node type used for non-rendered services (e.g., logic or audio)
+class ServiceNode : public SceneNode
+{
+public:
+    ServiceNode() = default;
+    void render(Renderer* renderer) override {} // no drawing
+};
+
+} // namespace FinalStorm


### PR DESCRIPTION
## Summary
- extend `MetalRenderer` with separate rendering pass methods
- add scene graph classes `SceneNode` and `ServiceNode`
- connect visible entities to scene graph in update step
- allocate basic resources for shadow map, post-processing, and cubemap
- include new sources in CMake build
- refine scene graph node logic and hierarchy

## Testing
- `./verify_structure.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850f873c30083328251ef3f64246c65