### PR TITLE
Implement WebSocket networking

### DIFF
--- a/Shared/Core/Networking/FinalverseClient.h
+++ b/Shared/Core/Networking/FinalverseClient.h
@@ -14,19 +14,14 @@
 #include <queue>
 #include <mutex>
 #include "../Math/Math.h"
+#include "MessageProtocol.h"
+#include "../Visualization/DataVisualizer.h"
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_no_tls_client.hpp>
 
 namespace FinalStorm {
 
 class WorldManager;
-
-enum class MessageType : uint32_t {
-    Unknown = 0,
-    Connect = 1,
-    WorldUpdate = 2,
-    EntityUpdate = 3,
-    PositionUpdate = 4,
-    Disconnect = 5
-};
 
 struct Message {
     MessageType type;
@@ -42,6 +37,8 @@ public:
     using DisconnectCallback = std::function<void()>;
     
     void connect(const std::string& host, uint16_t port, ConnectCallback callback);
+    void connectToServer(const std::string& url);
+    void subscribeToServices(const std::vector<std::string>& services);
     void disconnect();
     bool isConnected() const { return m_connected; }
     
@@ -49,33 +46,32 @@ public:
     void sendMessage(MessageType type, const void* data, size_t size);
     
     void setWorldManager(WorldManager* worldManager) { m_worldManager = worldManager; }
+    void setDataVisualizer(DataVisualizer* viz) { m_dataVisualizer = viz; }
     void setDisconnectCallback(DisconnectCallback callback) { m_disconnectCallback = callback; }
     
     void update(); // Call from main thread to process received messages
     
 private:
-    void networkThread();
     void processMessage(const Message& msg);
-    void handleEntityUpdate(const Message& msg) {} // Add this
+    void handleEntityUpdate(const Message& msg) {}
     
     bool m_connected;
     std::string m_host;
     uint16_t m_port;
-    
-    std::unique_ptr<std::thread> m_networkThread;
+
     std::atomic<bool> m_running;
-    
-    // Message queues
-    std::queue<Message> m_sendQueue;
+
+    // Received messages
     std::queue<Message> m_receiveQueue;
-    mutable std::mutex m_sendMutex;
     mutable std::mutex m_receiveMutex;
-    
-    // Socket handle (platform specific)
-    int m_socket;
-    
-    // Callbacks
+
+    using WSClient = websocketpp::client<websocketpp::config::asio_client>;
+    WSClient m_client;
+    websocketpp::connection_hdl m_connection;
+    std::unique_ptr<websocketpp::lib::thread> m_wsThread;
+
     WorldManager* m_worldManager;
+    DataVisualizer* m_dataVisualizer;
     ConnectCallback m_connectCallback;
     DisconnectCallback m_disconnectCallback;
 };


### PR DESCRIPTION
## Summary
- replace raw socket networking with websocketpp client
- add `connectToServer` and `subscribeToServices` helpers
- stream service metrics and forward messages to `WorldManager` and `DataVisualizer`

## Testing
- `./verify_structure.sh`

------
https://chatgpt.com/codex/tasks/task_e_685110d60d54833296d6ea7077a19cf8