### PR TITLE
Add service scene management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,10 @@ set(SHARED_SOURCES
     Shared/SceneGraph/ServiceNode.cpp
     Shared/Core/Services/WebServerViz.cpp
     Shared/Core/Services/DatabaseViz.cpp
+    Shared/Core/Services/ServiceEntity.cpp
     Shared/Core/Environment/EnvironmentController.cpp
     Shared/Core/Visualization/DataVisualizer.cpp
+    Shared/Core/World/SceneManager.cpp
     Shared/UI3D/Panel.cpp
     Shared/UI3D/HolographicDisplay.cpp
     Shared/UI3D/InteractiveOrb.cpp

--- a/Shared/Core/Services/ServiceEntity.cpp
+++ b/Shared/Core/Services/ServiceEntity.cpp
@@ -1,0 +1,28 @@
+#include "ServiceEntity.h"
+#include "../Math/Math.h"
+
+namespace FinalStorm {
+
+ServiceEntity::ServiceEntity(uint64_t id, const ServiceInfo& info)
+    : Entity(id, EntityType::Object),
+      m_info(info),
+      m_activityLevel(0.0f)
+{
+    m_meshName = "service";
+}
+
+void ServiceEntity::updateMetrics(const ServiceMetrics& metrics)
+{
+    m_metrics = metrics;
+    // Basic heuristic for activity level
+    m_activityLevel = (metrics.cpuUsage + metrics.memoryUsage) * 0.5f / 100.0f;
+    m_activityLevel = fmaxf(0.0f, fminf(1.0f, m_activityLevel));
+}
+
+void ServiceEntity::update(float deltaTime)
+{
+    Entity::update(deltaTime);
+    (void)deltaTime; // placeholder for future animations based on activity
+}
+
+} // namespace FinalStorm

--- a/Shared/Core/Services/ServiceEntity.h
+++ b/Shared/Core/Services/ServiceEntity.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../World/Entity.h"
+#include <string>
+#include <memory>
+
+namespace FinalStorm {
+
+class ServiceEntity : public Entity {
+public:
+    enum class ServiceType {
+        API_GATEWAY,
+        AI_ORCHESTRA,
+        SONG_ENGINE,
+        ECHO_ENGINE,
+        WORLD_ENGINE,
+        HARMONY_SERVICE,
+        ASSET_SERVICE,
+        COMMUNITY,
+        SILENCE_SERVICE,
+        PROCEDURAL_GEN,
+        BEHAVIOR_AI
+    };
+
+    struct ServiceInfo {
+        std::string name;
+        std::string url;
+        ServiceType type;
+        int port;
+        bool isHealthy = true;
+    };
+
+    struct ServiceMetrics {
+        float cpuUsage = 0.0f;
+        float memoryUsage = 0.0f;
+        int activeConnections = 0;
+        float responseTime = 0.0f;
+        float requestsPerSecond = 0.0f;
+    };
+
+    ServiceEntity(uint64_t id, const ServiceInfo& info);
+
+    void updateMetrics(const ServiceMetrics& metrics);
+    void update(float deltaTime) override;
+
+    const ServiceInfo& getInfo() const { return m_info; }
+    const ServiceMetrics& getMetrics() const { return m_metrics; }
+    float getActivityLevel() const { return m_activityLevel; }
+
+private:
+    ServiceInfo m_info;
+    ServiceMetrics m_metrics;
+    float m_activityLevel;
+};
+
+using ServiceEntityPtr = std::shared_ptr<ServiceEntity>;
+
+} // namespace FinalStorm

--- a/Shared/Core/World/SceneManager.cpp
+++ b/Shared/Core/World/SceneManager.cpp
@@ -1,0 +1,65 @@
+#include "SceneManager.h"
+#include "../Math/Math.h"
+
+namespace FinalStorm {
+
+SceneManager::SceneManager(std::shared_ptr<WorldManager> world)
+    : m_world(std::move(world)),
+      m_circleCenter(make_float2(0.0f, 0.0f)),
+      m_circleRadius(8.0f)
+{
+}
+
+void SceneManager::initializeServices()
+{
+    std::vector<ServiceEntity::ServiceInfo> defaults = {
+        {"API Gateway", "http://localhost:8080/health", ServiceEntity::ServiceType::API_GATEWAY, 8080},
+        {"AI Orchestra", "http://localhost:3004/health", ServiceEntity::ServiceType::AI_ORCHESTRA, 3004}
+    };
+    for (const auto& info : defaults)
+        addService(info);
+}
+
+ServiceEntityPtr SceneManager::addService(const ServiceEntity::ServiceInfo& info)
+{
+    uint64_t id = static_cast<uint64_t>(m_services.size() + 100);
+    auto service = std::make_shared<ServiceEntity>(id, info);
+
+    int index = static_cast<int>(m_services.size());
+    float angle = (index / 10.0f) * 2.0f * static_cast<float>(M_PI);
+    service->getTransform().position = make_float3(
+        cosf(angle) * m_circleRadius,
+        0.0f,
+        sinf(angle) * m_circleRadius);
+
+    if (m_world)
+        m_world->addEntity(service);
+
+    m_services[info.name] = service;
+    return service;
+}
+
+void SceneManager::removeService(const std::string& name)
+{
+    auto it = m_services.find(name);
+    if (it != m_services.end()) {
+        if (m_world)
+            m_world->removeEntity(it->second->getId());
+        m_services.erase(it);
+    }
+}
+
+ServiceEntityPtr SceneManager::getService(const std::string& name) const
+{
+    auto it = m_services.find(name);
+    return it != m_services.end() ? it->second : nullptr;
+}
+
+void SceneManager::updateServiceMetrics(const std::string& name,
+                                        const ServiceEntity::ServiceMetrics& metrics)
+{
+    if (auto service = getService(name))
+        service->updateMetrics(metrics);
+}
+
+} // namespace FinalStorm

--- a/Shared/Core/World/SceneManager.h
+++ b/Shared/Core/World/SceneManager.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "WorldManager.h"
+#include "../Services/ServiceEntity.h"
+#include <map>
+#include <memory>
+
+namespace FinalStorm {
+
+class SceneManager {
+public:
+    explicit SceneManager(std::shared_ptr<WorldManager> world);
+
+    void initializeServices();
+
+    ServiceEntityPtr addService(const ServiceEntity::ServiceInfo& info);
+    void removeService(const std::string& name);
+    ServiceEntityPtr getService(const std::string& name) const;
+
+    void updateServiceMetrics(const std::string& name,
+                              const ServiceEntity::ServiceMetrics& metrics);
+
+private:
+    std::shared_ptr<WorldManager> m_world;
+    std::map<std::string, ServiceEntityPtr> m_services;
+
+    float2 m_circleCenter;
+    float  m_circleRadius;
+};
+
+} // namespace FinalStorm


### PR DESCRIPTION
## Summary
- create `ServiceEntity` for representing Finalverse services
- add `SceneManager` to manage service entities
- integrate new sources in `CMakeLists.txt`

## Testing
- `./verify_structure.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851185feb6c8332aea7078c65e6da8e