### PR TITLE
Normalize include paths

### DIFF
--- a/src/Core/Audio/AudioEngine.cpp
+++ b/src/Core/Audio/AudioEngine.cpp
@@ -5,7 +5,7 @@
 //  Created by Wenyan Qin on 2025-06-16.
 //
 
-#include "AudioEngine.h"
+#include "Core/Audio/AudioEngine.h"
 #include <iostream>
 
 namespace FinalStorm {

--- a/src/Core/Audio/AudioEngine.h
+++ b/src/Core/Audio/AudioEngine.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
-#include "../Math/Math.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Audio/SpatialAudioSystem.cpp
+++ b/src/Core/Audio/SpatialAudioSystem.cpp
@@ -1,4 +1,4 @@
-#include "SpatialAudioSystem.h"
+#include "Core/Audio/SpatialAudioSystem.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Audio/SpatialAudioSystem.h
+++ b/src/Core/Audio/SpatialAudioSystem.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "AudioEngine.h"
-#include "../../Scene/ServiceNode.h"
-#include "../Environment/EnvironmentController.h"
+#include "Core/Audio/AudioEngine.h"
+#include "Services/ServiceNode.h"
+#include "Core/Environment/EnvironmentController.h"
 #include <unordered_map>
 #include <memory>
 

--- a/src/Core/Environment/EnvironmentController.cpp
+++ b/src/Core/Environment/EnvironmentController.cpp
@@ -1,4 +1,4 @@
-#include "Environment/EnvironmentController.h"
+#include "Core/Environment/EnvironmentController.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Environment/EnvironmentController.h
+++ b/src/Core/Environment/EnvironmentController.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Math/Math.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Input/InteractionManager.cpp
+++ b/src/Core/Input/InteractionManager.cpp
@@ -1,7 +1,7 @@
-#include "InteractionManager.h"
-#include "../Math/Math.h"
-#include "../../Scene/SceneNode.h"
-#include "../Math/Math.h"
+#include "Core/Input/InteractionManager.h"
+#include "Core/Math/Math.h"
+#include "Scene/SceneNode.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Input/InteractionManager.h
+++ b/src/Core/Input/InteractionManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Math/Math.h"
+#include "Core/Math/Math.h"
 #include <memory>
 
 namespace FinalStorm {

--- a/src/Core/Math/Math.cpp
+++ b/src/Core/Math/Math.cpp
@@ -5,8 +5,8 @@
 //  Created by Wenyan Qin on 2025-06-15.
 //
 
-#include "Math.h"
-#include "Transform.h"
+#include "Core/Math/Math.h"
+#include "Core/Math/Transform.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Math/Transform.h
+++ b/src/Core/Math/Transform.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "Math.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Networking/FinalverseClient.cpp
+++ b/src/Core/Networking/FinalverseClient.cpp
@@ -5,8 +5,8 @@
 //  Created by Wenyan Qin on 2025-06-15.
 //
 
-#include "FinalverseClient.h"
-#include "../World/WorldManager.h"
+#include "Core/Networking/FinalverseClient.h"
+#include "Core/World/WorldManager.h"
 #include <websocketpp/config/asio_no_tls_client.hpp>
 #include <websocketpp/client.hpp>
 #include <websocketpp/common/thread.hpp>

--- a/src/Core/Networking/FinalverseClient.h
+++ b/src/Core/Networking/FinalverseClient.h
@@ -13,9 +13,9 @@
 #include <thread>
 #include <queue>
 #include <mutex>
-#include "../Math/Math.h"
-#include "MessageProtocol.h"
-#include "../Visualization/DataVisualizer.h"
+#include "Core/Math/Math.h"
+#include "Core/Networking/MessageProtocol.h"
+#include "Core/Visualization/DataVisualizer.h"
 #include <websocketpp/client.hpp>
 #include <websocketpp/config/asio_no_tls_client.hpp>
 

--- a/src/Core/Networking/MessageProtocol.cpp
+++ b/src/Core/Networking/MessageProtocol.cpp
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 #include <cstring>
-#include "MessageProtocol.h"
+#include "Core/Networking/MessageProtocol.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Networking/MessageProtocol.h
+++ b/src/Core/Networking/MessageProtocol.h
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
-#include "../Math/Math.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Visualization/DataVisualizer.cpp
+++ b/src/Core/Visualization/DataVisualizer.cpp
@@ -1,4 +1,4 @@
-#include "Visualization/DataVisualizer.h"
+#include "Core/Visualization/DataVisualizer.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Visualization/DataVisualizer.h
+++ b/src/Core/Visualization/DataVisualizer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Environment/EnvironmentController.h"
+#include "Core/Environment/EnvironmentController.h"
 
 namespace FinalStorm {
 

--- a/src/Core/World/Entity.cpp
+++ b/src/Core/World/Entity.cpp
@@ -7,7 +7,7 @@
 //  Created by Wenyan Qin on 2025-06-16.
 //
 
-#include "Entity.h"
+#include "Core/World/Entity.h"
 
 namespace FinalStorm {
 

--- a/src/Core/World/Entity.h
+++ b/src/Core/World/Entity.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include "../Math/Math.h"
-#include "../Math/Transform.h"  // Add this include
+#include "Core/Math/Math.h"
+#include "Core/Math/Transform.h"  // Add this include
 #include <string>
 #include <memory>
 #include <vector>

--- a/src/Core/World/WorldManager.cpp
+++ b/src/Core/World/WorldManager.cpp
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 #include <algorithm>
-#include "WorldManager.h"
+#include "Core/World/WorldManager.h"
 
 namespace FinalStorm {
 

--- a/src/Core/World/WorldManager.h
+++ b/src/Core/World/WorldManager.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include "Entity.h"
-#include "../Math/Math.h"
+#include "Core/World/Entity.h"
+#include "Core/Math/Math.h"
 #include <vector>
 #include <unordered_map>
 #include <memory>

--- a/src/Platform/iOS/ARMode.h
+++ b/src/Platform/iOS/ARMode.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <ARKit/ARKit.h>
-#import "../../Rendering/Metal/MetalRenderer.h"
-#include "../../Core/Services/ServiceRepresentation.h"
+#import "Renderer/Metal/MetalRenderer.h"
+#include "Services/ServiceRepresentation.h"
 #include <memory>
 
 @class MetalRenderer;

--- a/src/Platform/iOS/GameViewController.h
+++ b/src/Platform/iOS/GameViewController.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 #import <Metal/Metal.h>
 #import <MetalKit/MetalKit.h>
-#import "../../Rendering/Metal/MetalRenderer.h"
+#import "Renderer/Metal/MetalRenderer.h"
 
 // Our iOS view controller
 @interface GameViewController : UIViewController

--- a/src/Platform/iOS/GameViewController.mm
+++ b/src/Platform/iOS/GameViewController.mm
@@ -6,8 +6,8 @@
 //
 
 #import "GameViewController.h"
-#include "../../Core/Networking/FinalverseClient.h"
-#include "../../Core/Input/InteractionManager.h"
+#include "Core/Networking/FinalverseClient.h"
+#include "Core/Input/InteractionManager.h"
 #import "ARMode.h"
 
 @implementation GameViewController

--- a/src/Platform/macOS/GameViewController.h
+++ b/src/Platform/macOS/GameViewController.h
@@ -8,7 +8,7 @@
 #import <Cocoa/Cocoa.h>
 #import <Metal/Metal.h>
 #import <MetalKit/MetalKit.h>
-#import "../../Rendering/Metal/MetalRenderer.h"
+#import "Renderer/Metal/MetalRenderer.h"
 
 @interface GameViewController : NSViewController
 

--- a/src/Platform/macOS/GameViewController.mm
+++ b/src/Platform/macOS/GameViewController.mm
@@ -6,8 +6,8 @@
 //
 
 #import "GameViewController.h"
-#include "../../Core/Networking/FinalverseClient.h"
-#include "../../Core/Input/InteractionManager.h"
+#include "Core/Networking/FinalverseClient.h"
+#include "Core/Input/InteractionManager.h"
 
 @implementation GameViewController
 {

--- a/src/Renderer/Metal/MetalRenderer.h
+++ b/src/Renderer/Metal/MetalRenderer.h
@@ -10,9 +10,9 @@ typedef NSPoint FSPoint;
 typedef CGPoint FSPoint;
 #endif
 
-#include "../../Core/Math/Math.h"
-#include "../../Core/World/WorldManager.h"
-#include "../../Scene/SceneNode.h"
+#include "Core/Math/Math.h"
+#include "Core/World/WorldManager.h"
+#include "Scene/SceneNode.h"
 #include <memory>
 
 @interface MetalRenderer : NSObject<MTKViewDelegate>

--- a/src/Renderer/Metal/MetalRenderer.mm
+++ b/src/Renderer/Metal/MetalRenderer.mm
@@ -7,13 +7,13 @@
 
 #import "MetalRenderer.h"
 #import "MetalShaderTypes.h"
-#include "../../Core/World/Entity.h"
-#include "../../Scene/SceneNode.h"
-#include "../../Core/Services/WebServerViz.h"
-#include "../../Core/Services/DatabaseViz.h"
-#include "../../Core/Environment/EnvironmentController.h"
-#include "../../Core/Visualization/DataVisualizer.h"
-#include "../../Core/Audio/SpatialAudioSystem.h"
+#include "Core/World/Entity.h"
+#include "Scene/SceneNode.h"
+#include "Services/Visualizations/WebServerViz.h"
+#include "Services/Visualizations/DatabaseViz.h"
+#include "Core/Environment/EnvironmentController.h"
+#include "Core/Visualization/DataVisualizer.h"
+#include "Core/Audio/SpatialAudioSystem.h"
 #include <vector>
 #include <unordered_set>
 

--- a/src/Renderer/Renderer.h
+++ b/src/Renderer/Renderer.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "../Core/Math/Math.h"
+#include "Core/Math/Math.h"
 #include <memory>
 #include <string>
 

--- a/src/Renderer/ShaderTypes.h
+++ b/src/Renderer/ShaderTypes.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "../Core/Math/Math.h"
+#include "Core/Math/Math.h"
 
 // Shared shader data structures between C++ and Metal/Vulkan/DX12
 

--- a/src/Scene/SceneLoader.cpp
+++ b/src/Scene/SceneLoader.cpp
@@ -1,6 +1,6 @@
 // SceneLoader.cpp - Implementation
 
-#include "SceneLoader.h"
+#include "Scene/SceneLoader.h"
 #include "Core/World/WorldManager.h"
 #include "Rendering/Metal/MetalRenderer.h"
 #include "Core/Networking/FinalverseClient.h"

--- a/src/Scene/SceneManager.cpp
+++ b/src/Scene/SceneManager.cpp
@@ -1,5 +1,5 @@
-#include "SceneManager.h"
-#include "../Math/Math.h"
+#include "Scene/SceneManager.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Scene/SceneManager.h
+++ b/src/Scene/SceneManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "WorldManager.h"
-#include "../Services/ServiceEntity.h"
+#include "Core/World/WorldManager.h"
+#include "Services/ServiceEntity.h"
 #include <map>
 #include <memory>
 

--- a/src/Scene/SceneNode.cpp
+++ b/src/Scene/SceneNode.cpp
@@ -1,5 +1,5 @@
 #include "Scene/SceneNode.h"
-#include "../Renderer/Renderer.h"
+#include "Renderer/Renderer.h"
 #include <algorithm>
 
 namespace FinalStorm {

--- a/src/Scene/SceneNode.h
+++ b/src/Scene/SceneNode.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "../Core/Math/Math.h"
-#include "../Core/Math/Transform.h"
-#include "../Core/World/Entity.h"
+#include "Core/Math/Math.h"
+#include "Core/Math/Transform.h"
+#include "Core/World/Entity.h"
 #include <memory>
 #include <vector>
 

--- a/src/Services/ServiceEntity.cpp
+++ b/src/Services/ServiceEntity.cpp
@@ -1,5 +1,5 @@
 #include "Services/ServiceEntity.h"
-#include "../Math/Math.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/Services/ServiceEntity.h
+++ b/src/Services/ServiceEntity.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Core/World/Entity.h"
+#include "Core/World/Entity.h"
 #include <string>
 #include <memory>
 

--- a/src/Services/ServiceFactory.cpp
+++ b/src/Services/ServiceFactory.cpp
@@ -1,12 +1,12 @@
 // ServiceFactory.cpp - Implementation of service factory
 
-#include "ServiceFactory.h"
-#include "Visualizations/APIGatewayViz.h"
-#include "Visualizations/AIServiceViz.h"
-#include "Visualizations/AudioServiceViz.h"
-#include "Visualizations/WorldEngineViz.h"
-#include "Visualizations/DatabaseViz.h"
-#include "Visualizations/CommunityViz.h"
+#include "Services/ServiceFactory.h"
+#include "Services/Visualizations/APIGatewayViz.h"
+#include "Services/Visualizations/AIServiceViz.h"
+#include "Services/Visualizations/AudioServiceViz.h"
+#include "Services/Visualizations/WorldEngineViz.h"
+#include "Services/Visualizations/DatabaseViz.h"
+#include "Services/Visualizations/CommunityViz.h"
 
 namespace FinalStorm {
 

--- a/src/Services/ServiceRepresentation.h
+++ b/src/Services/ServiceRepresentation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ServiceNode.h"
+#include "Services/ServiceNode.h"
 #include <string>
 
 namespace FinalStorm {

--- a/src/Services/ServiceVisualizations.h
+++ b/src/Services/ServiceVisualizations.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "Scene/SceneNode.h"
-#include "../Core/Math/Math.h"
+#include "Core/Math/Math.h"
 #include <random>
 
 namespace FinalStorm {

--- a/src/Services/Visualizations/DatabaseViz.cpp
+++ b/src/Services/Visualizations/DatabaseViz.cpp
@@ -1,5 +1,5 @@
-#include "DatabaseViz.h"
-#include "../../Scene/SceneNode.h"
+#include "Services/Visualizations/DatabaseViz.h"
+#include "Scene/SceneNode.h"
 
 namespace FinalStorm {
 

--- a/src/Services/Visualizations/WebServerViz.cpp
+++ b/src/Services/Visualizations/WebServerViz.cpp
@@ -1,5 +1,5 @@
-#include "WebServerViz.h"
-#include "../../Scene/SceneNode.h"
+#include "Services/Visualizations/WebServerViz.h"
+#include "Scene/SceneNode.h"
 
 namespace FinalStorm {
 

--- a/src/UI/HolographicDisplay.cpp
+++ b/src/UI/HolographicDisplay.cpp
@@ -1,5 +1,5 @@
-#include "HolographicDisplay.h"
-#include "../Renderer/Renderer.h"
+#include "UI/HolographicDisplay.h"
+#include "Renderer/Renderer.h"
 
 namespace FinalStorm {
 

--- a/src/UI/HolographicDisplay.h
+++ b/src/UI/HolographicDisplay.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../Scene/SceneNode.h"
-#include "UI3DPanel.h"
+#include "Scene/SceneNode.h"
+#include "UI/UI3DPanel.h"
 #include <memory>
 
 namespace FinalStorm {

--- a/src/UI/InteractiveOrb.cpp
+++ b/src/UI/InteractiveOrb.cpp
@@ -1,5 +1,5 @@
-#include "InteractiveOrb.h"
-#include "../Renderer/Renderer.h"
+#include "UI/InteractiveOrb.h"
+#include "Renderer/Renderer.h"
 
 namespace FinalStorm {
 

--- a/src/UI/InteractiveOrb.h
+++ b/src/UI/InteractiveOrb.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Scene/SceneNode.h"
+#include "Scene/SceneNode.h"
 #include <functional>
 
 namespace FinalStorm {

--- a/src/UI/Panel.cpp
+++ b/src/UI/Panel.cpp
@@ -1,5 +1,5 @@
-#include "UI3DPanel.h"
-#include "../Renderer/Renderer.h"
+#include "UI/UI3DPanel.h"
+#include "Renderer/Renderer.h"
 
 namespace FinalStorm {
 

--- a/src/UI/Panel.h
+++ b/src/UI/Panel.h
@@ -2,7 +2,7 @@
 
 #include <functional>
 #include <string>
-#include "../Core/Math/Math.h"
+#include "Core/Math/Math.h"
 
 namespace FinalStorm {
 

--- a/src/UI/UI3DPanel.cpp
+++ b/src/UI/UI3DPanel.cpp
@@ -1,4 +1,4 @@
-#include "UI3DPanel.h"
+#include "UI/UI3DPanel.h"
 #include "Core/ResourceManager.h"
 #include "Core/Transform.h"
 #include "Graphics/Material.h"


### PR DESCRIPTION
## Summary
- switch all local includes to start at the `src` root
- keep `src` as a private include directory for each target

## Testing
- `cmake -S . -B build` *(fails: Could not find METAL_FRAMEWORK)*

------
https://chatgpt.com/codex/tasks/task_e_6852e4bd849083328934d59523cafac5