### PR TITLE
Unify networking sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SHARED_SOURCES
     src/World/WorldManager.cpp
     src/Core/Networking/FinalverseClient.cpp
     src/Core/Networking/MessageProtocol.cpp
+    src/Core/Networking/NetworkClient.cpp
     src/Core/Audio/AudioEngine.cpp
     src/Core/Audio/SpatialAudioSystem.cpp
     src/Core/Input/InteractionManager.cpp

--- a/include/FinalStorm/Networking/NetworkClient.h
+++ b/include/FinalStorm/Networking/NetworkClient.h
@@ -1,0 +1,89 @@
+// Networking/NetworkClient.h
+#pragma once
+
+#include <string>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <unordered_map>
+
+namespace FinalStorm {
+
+class WebSocketClient;
+
+enum class ConnectionState {
+    Disconnected,
+    Connecting,
+    Connected,
+    Disconnecting,
+    Error
+};
+
+struct ServiceInfo {
+    std::string id;
+    std::string name;
+    std::string type;
+    std::string url;
+    bool isHealthy;
+    float cpuUsage;
+    float memoryUsage;
+    int activeConnections;
+};
+
+struct NetworkMessage {
+    std::string type;
+    std::string payload;
+    double timestamp;
+};
+
+class NetworkClient {
+public:
+    using ConnectionCallback = std::function<void(ConnectionState)>;
+    using MessageCallback = std::function<void(const NetworkMessage&)>;
+    using ServiceCallback = std::function<void(const ServiceInfo&)>;
+
+    NetworkClient();
+    ~NetworkClient();
+
+    void connect(const std::string& serverUrl);
+    void disconnect();
+    bool isConnected() const { return m_state == ConnectionState::Connected; }
+    ConnectionState getState() const { return m_state; }
+
+    void sendMessage(const std::string& type, const std::string& payload);
+    void setMessageCallback(MessageCallback callback) { m_messageCallback = callback; }
+
+    void requestServiceList();
+    void subscribeToService(const std::string& serviceId);
+    void unsubscribeFromService(const std::string& serviceId);
+    void setServiceCallback(ServiceCallback callback) { m_serviceCallback = callback; }
+
+    void setConnectionCallback(ConnectionCallback callback) { m_connectionCallback = callback; }
+
+    void update();
+
+private:
+    void processMessageQueue();
+    void handleMessage(const std::string& message);
+    void parseServiceUpdate(const std::string& payload);
+
+    std::unique_ptr<WebSocketClient> m_webSocket;
+    ConnectionState m_state = ConnectionState::Disconnected;
+
+    ConnectionCallback m_connectionCallback;
+    MessageCallback m_messageCallback;
+    ServiceCallback m_serviceCallback;
+
+    std::queue<NetworkMessage> m_messageQueue;
+    mutable std::mutex m_queueMutex;
+
+    std::unordered_map<std::string, ServiceInfo> m_services;
+
+    std::thread m_networkThread;
+    std::atomic<bool> m_running{false};
+};
+
+} // namespace FinalStorm

--- a/src/Core/Networking/NetworkClient.cpp
+++ b/src/Core/Networking/NetworkClient.cpp
@@ -1,0 +1,96 @@
+#include "Core/Networking/NetworkClient.h"
+#include <iostream>
+
+namespace FinalStorm {
+
+namespace {
+// Simple placeholder WebSocket client used for compiling the sample project.
+class WebSocketClient {
+public:
+    void connect(const std::string& url) {
+        std::cout << "[Network] connect " << url << std::endl;
+    }
+    void disconnect() {
+        std::cout << "[Network] disconnect" << std::endl;
+    }
+    void send(const std::string& msg) {
+        std::cout << "[Network] send: " << msg << std::endl;
+    }
+};
+} // namespace
+
+NetworkClient::NetworkClient() = default;
+
+NetworkClient::~NetworkClient() {
+    disconnect();
+}
+
+void NetworkClient::connect(const std::string& serverUrl) {
+    if (m_state != ConnectionState::Disconnected) return;
+    m_state = ConnectionState::Connecting;
+    m_webSocket = std::make_unique<WebSocketClient>();
+    m_webSocket->connect(serverUrl);
+    m_state = ConnectionState::Connected;
+    m_running = true;
+    if (m_connectionCallback) m_connectionCallback(m_state);
+}
+
+void NetworkClient::disconnect() {
+    if (m_state == ConnectionState::Disconnected) return;
+    m_state = ConnectionState::Disconnecting;
+    if (m_webSocket) {
+        m_webSocket->disconnect();
+    }
+    m_state = ConnectionState::Disconnected;
+    m_running = false;
+    if (m_connectionCallback) m_connectionCallback(m_state);
+}
+
+void NetworkClient::sendMessage(const std::string& type, const std::string& payload) {
+    if (!m_webSocket) return;
+    m_webSocket->send(type + ":" + payload);
+}
+
+void NetworkClient::requestServiceList() {
+    sendMessage("requestServiceList", "");
+}
+
+void NetworkClient::subscribeToService(const std::string& serviceId) {
+    sendMessage("subscribe", serviceId);
+}
+
+void NetworkClient::unsubscribeFromService(const std::string& serviceId) {
+    sendMessage("unsubscribe", serviceId);
+}
+
+void NetworkClient::update() {
+    if (!m_running) return;
+    processMessageQueue();
+}
+
+void NetworkClient::processMessageQueue() {
+    std::queue<NetworkMessage> local;
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        std::swap(local, m_messageQueue);
+    }
+    while (!local.empty()) {
+        if (m_messageCallback) m_messageCallback(local.front());
+        local.pop();
+    }
+}
+
+void NetworkClient::handleMessage(const std::string& message) {
+    NetworkMessage msg{ "generic", message, 0.0 };
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    m_messageQueue.push(msg);
+}
+
+void NetworkClient::parseServiceUpdate(const std::string& payload) {
+    ServiceInfo info{};
+    info.id = payload;
+    m_services[info.id] = info;
+    if (m_serviceCallback) m_serviceCallback(info);
+}
+
+} // namespace FinalStorm

--- a/src/Core/Networking/NetworkClient.h
+++ b/src/Core/Networking/NetworkClient.h
@@ -1,4 +1,4 @@
-// Network/NetworkClient.h
+// Core/Networking/NetworkClient.h
 #pragma once
 
 #include <string>
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <thread>
 #include <atomic>
+#include <unordered_map>
 
 namespace FinalStorm {
 

--- a/src/FinalStormApp.cpp
+++ b/src/FinalStormApp.cpp
@@ -1,6 +1,6 @@
 // FinalStormApp.cpp
 #include "FinalStormApp.h"
-#include "Network/NetworkClient.h"              // You need to add this
+#include "Core/Networking/NetworkClient.h"
 #include "Core/Input/InputManager.h"            // The new low-level input manager
 #include "Core/Input/InteractionManager.h"      // Existing high-level interaction
 #include "Renderer/MetalRenderer.h"             // Use existing renderer


### PR DESCRIPTION
## Summary
- keep networking code under `src/Core/Networking`
- add stub implementation of `NetworkClient`
- expose `NetworkClient` via public headers
- update includes and build files
- remove old `src/Network` location

## Testing
- `./verify_structure.sh` *(fails: Missing: src/Renderer/Metal/MetalRenderer.h)*

------
https://chatgpt.com/codex/tasks/task_e_685363468e6c8332a20c06ebe49cd79a