### PR TITLE
Fix MathTypes header includes

### DIFF
--- a/src/Core/Input/InputTypes.h
+++ b/src/Core/Input/InputTypes.h
@@ -3,7 +3,7 @@
 // Common types for input handling
 
 #pragma once
-#include "Core/Math/MathTypes.h"
+#include "Core/MathTypes.h"
 
 namespace FinalStorm {
 

--- a/src/Core/Math/Camera.h
+++ b/src/Core/Math/Camera.h
@@ -3,7 +3,7 @@
 // Manages view and projection matrices
 
 #pragma once
-#include "Core/Math/MathTypes.h"
+#include "Core/MathTypes.h"
 #include "Core/Math/Transform.h"
 
 namespace FinalStorm {

--- a/src/Rendering/RenderContext.h
+++ b/src/Rendering/RenderContext.h
@@ -3,7 +3,7 @@
 // Provides drawing commands for a frame
 
 #pragma once
-#include "Core/Math/MathTypes.h"
+#include "Core/MathTypes.h"
 #include <stack>
 
 namespace FinalStorm {

--- a/src/Rendering/Renderer.h
+++ b/src/Rendering/Renderer.h
@@ -3,7 +3,7 @@
 // Defines the common interface for all rendering backends
 
 #pragma once
-#include "Core/Math/MathTypes.h"
+#include "Core/MathTypes.h"
 #include <memory>
 
 namespace FinalStorm {

--- a/src/Scene/CameraController.h
+++ b/src/Scene/CameraController.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "../Core/Math/MathTypes.h"
+#include "../Core/MathTypes.h"
 
 namespace FinalStorm {
 

--- a/src/Scene/Scene.h
+++ b/src/Scene/Scene.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "../Core/Math/MathTypes.h"
+#include "../Core/MathTypes.h"
 #include <vector>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Summary
- adjust includes to use `Core/MathTypes.h`
- keep source directory listed as an include path

## Testing
- `clang++ -std=c++17 -I./src -I./include -fsyntax-only src/Rendering/Camera.h` *(fails: 'glm/glm.hpp' file not found)*
- `clang++ -std=c++17 -I./src -I./include -fsyntax-only src/Core/Input/InputTypes.h` *(fails: 'glm/glm.hpp' file not found)*
- `clang++ -std=c++17 -I./src -I./include -fsyntax-only src/Rendering/Renderer.h` *(fails: 'glm/glm.hpp' file not found)*
- `clang++ -std=c++17 -I./src -I./include -fsyntax-only src/Rendering/RenderContext.h` *(fails: 'glm/glm.hpp' file not found)*
- `clang++ -std=c++17 -I./src -I./include -fsyntax-only src/Scene/Scene.h` *(fails: 'glm/glm.hpp' file not found)*
- `clang++ -std=c++17 -I./src -I./include -fsyntax-only src/Scene/CameraController.h` *(fails: 'glm/glm.hpp' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855254ea04c83328290abede545a98c