### PR TITLE
Enable unified macOS/iOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,11 @@ if(NOT APPLE)
 endif()
 
 # Options
-option(BUILD_FOR_IOS "Build for iOS instead of macOS" OFF)
+option(BUILD_IOS_ONLY "Build only the iOS target" OFF)
+option(BUILD_MAC_ONLY "Build only the macOS target" OFF)
 
-# Set deployment target
-if(BUILD_FOR_IOS)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0")
-    set(CMAKE_OSX_ARCHITECTURES "arm64")
-else()
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+if(BUILD_IOS_ONLY AND BUILD_MAC_ONLY)
+    message(FATAL_ERROR "Only one of BUILD_IOS_ONLY or BUILD_MAC_ONLY can be ON")
 endif()
 
 # Output directories
@@ -65,41 +62,52 @@ set(METAL_SOURCES
 )
 
 # Platform-specific sources
-if(BUILD_FOR_IOS)
-    set(PLATFORM_SOURCES
-        src/Platform/iOS/main.mm
-        src/Platform/iOS/AppDelegate.mm
-        src/Platform/iOS/GameViewController.mm
-    )
-else()
-    set(PLATFORM_SOURCES
-        src/Platform/macOS/main.mm
+set(MACOS_SOURCES
+    src/Platform/macOS/main.mm
+    src/Platform/macOS/AppDelegate.mm
+    src/Platform/macOS/GameViewController.mm
+)
+
+set(IOS_SOURCES
+    src/Platform/iOS/main.mm
+    src/Platform/iOS/AppDelegate.mm
+    src/Platform/iOS/GameViewController.mm
+)
+
+# Shaders
+file(GLOB SHADER_FILES ${CMAKE_SOURCE_DIR}/shaders/*.metal)
+
+add_custom_target(Shaders
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/compile_shaders.sh --all
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Compiling Metal shaders"
+)
+
+########################################################################
+# Targets
+########################################################################
+
+if(NOT BUILD_IOS_ONLY)
+    add_executable(FinalStorm-macOS MACOSX_BUNDLE
+        ${CORE_SOURCES}
+        ${METAL_SOURCES}
+        ${MACOS_SOURCES}
     )
 endif()
 
-# Create executable
-add_executable(FinalStorm MACOSX_BUNDLE
-    ${CORE_SOURCES}
-    ${METAL_SOURCES}
-    ${PLATFORM_SOURCES}
-)
+if(NOT BUILD_MAC_ONLY)
+    add_executable(FinalStorm-iOS MACOSX_BUNDLE
+        ${CORE_SOURCES}
+        ${METAL_SOURCES}
+        ${IOS_SOURCES}
+    )
+endif()
 
-# Set bundle properties
-set_target_properties(FinalStorm PROPERTIES
-    MACOSX_BUNDLE_GUI_IDENTIFIER "com.finalverse.finalstorm"
-    MACOSX_BUNDLE_BUNDLE_NAME "FinalStorm"
-    MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0"
-    MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1"
-)
+########################################################################
+# Target configuration
+########################################################################
 
-# Include directories
-target_include_directories(FinalStorm PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-# Link frameworks
-target_link_libraries(FinalStorm PRIVATE
+set(COMMON_FRAMEWORKS
     "-framework Foundation"
     "-framework Metal"
     "-framework MetalKit"
@@ -108,43 +116,87 @@ target_link_libraries(FinalStorm PRIVATE
     Threads::Threads
 )
 
-if(BUILD_FOR_IOS)
-    target_link_libraries(FinalStorm PRIVATE
-        "-framework UIKit"
-        "-framework ARKit"
+if(NOT BUILD_IOS_ONLY)
+    set_target_properties(FinalStorm-macOS PROPERTIES
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.finalverse.finalstorm"
+        MACOSX_BUNDLE_BUNDLE_NAME "FinalStorm"
+        MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1"
+        MACOSX_DEPLOYMENT_TARGET "11.0"
     )
-else()
-    target_link_libraries(FinalStorm PRIVATE
+    target_include_directories(FinalStorm-macOS PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(FinalStorm-macOS PRIVATE
+        ${COMMON_FRAMEWORKS}
         "-framework Cocoa"
         "-framework AppKit"
     )
+    target_compile_definitions(FinalStorm-macOS PRIVATE USE_SIMD)
+    add_dependencies(FinalStorm-macOS Shaders)
+    add_custom_command(TARGET FinalStorm-macOS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/assets
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets
+    )
+    add_custom_command(TARGET FinalStorm-macOS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/shaders
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders
+    )
 endif()
 
-# Compile definitions
-target_compile_definitions(FinalStorm PRIVATE
-    USE_SIMD  # Use Apple's SIMD types
-)
+if(NOT BUILD_MAC_ONLY)
+    set_target_properties(FinalStorm-iOS PROPERTIES
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.finalverse.finalstorm"
+        MACOSX_BUNDLE_BUNDLE_NAME "FinalStorm"
+        MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1"
+        MACOSX_DEPLOYMENT_TARGET "14.0"
+        OSX_ARCHITECTURES "arm64"
+        XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+    )
+    target_include_directories(FinalStorm-iOS PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(FinalStorm-iOS PRIVATE
+        ${COMMON_FRAMEWORKS}
+        "-framework UIKit"
+        "-framework ARKit"
+    )
+    target_compile_definitions(FinalStorm-iOS PRIVATE USE_SIMD)
+    add_dependencies(FinalStorm-iOS Shaders)
+    add_custom_command(TARGET FinalStorm-iOS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/assets
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets
+    )
+    add_custom_command(TARGET FinalStorm-iOS POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/shaders
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders
+    )
+endif()
 
-# Copy shaders to build directory
-add_custom_command(TARGET FinalStorm POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_SOURCE_DIR}/shaders
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders
-)
-
-# Copy assets to build directory
-add_custom_command(TARGET FinalStorm POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_SOURCE_DIR}/assets
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets
-)
-
+########################################################################
 # Installation
-install(TARGETS FinalStorm
-    BUNDLE DESTINATION .
-    RUNTIME DESTINATION bin
-)
+########################################################################
 
-# Install shaders and assets
+if(NOT BUILD_IOS_ONLY)
+    install(TARGETS FinalStorm-macOS
+        BUNDLE DESTINATION .
+        RUNTIME DESTINATION bin
+    )
+endif()
+
+if(NOT BUILD_MAC_ONLY)
+    install(TARGETS FinalStorm-iOS
+        BUNDLE DESTINATION .
+        RUNTIME DESTINATION bin
+    )
+endif()
+
 install(DIRECTORY shaders DESTINATION bin)
-install(DIRECTORY assets DESTINATION bin)        
+install(DIRECTORY assets DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -26,17 +26,13 @@ To generate the Xcode project run:
 ./scripts/build_setup.sh --clean --open
 ```
 
-This script creates a `build` directory and produces `FinalStorm.xcodeproj`.
-Pass `--ios` to configure an iOS build. The `--open` flag launches Xcode once
-generation completes.
+This script creates a `build` directory and produces `FinalStorm.xcodeproj` with
+both macOS and iOS targets. The `--open` flag launches Xcode once generation
+completes. Use `--ios-only` or `--mac-only` if you want a single platform.
 
 
-When opening the generated project, ensure the **FinalStorm-iOS** target
-uses the iOS SDK. In Xcode's Build Settings, the **Base SDK** should be
-either *iPhoneOS* or *iPhoneSimulator*. If you see build errors such as
-`CVOpenGLESTexture.h` not found, the macOS SDK is selected by mistake.
-Adjust the SDK and verify the framework search paths do not reference
-`MacOSX.platform`.
+The project also includes a **Shaders** target which compiles all Metal shaders
+to verify they are valid for both platforms.
 
 See [docs/BUILD.md](docs/BUILD.md) for additional build information.
 
@@ -52,4 +48,5 @@ present. Run it from the repository root:
 ## License
 
 This project is provided for experimentation and is not yet production ready.
+
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -9,6 +9,8 @@ both macOS and iOS targets.
 ```
 
 This script generates a `build/` directory and optionally opens
-`FinalStorm.xcodeproj` when the `--open` flag is supplied. Pass `--ios`
-to configure for the iOS SDK. After configuring you can build either
+`FinalStorm.xcodeproj` when the `--open` flag is supplied. By default the
+project contains both macOS and iOS targets. You can restrict generation
+using `--ios-only` or `--mac-only`. After configuring you can build either
 from Xcode or via `cmake --build`.
+

--- a/scripts/build_setup.sh
+++ b/scripts/build_setup.sh
@@ -3,21 +3,26 @@
 
 set -e
 
-IOS=false
+IOS_ONLY=false
+MAC_ONLY=false
 CLEAN=false
 OPEN=false
 
 usage() {
-    echo "Usage: $0 [--ios] [--clean] [--open]"
-    echo "  --ios    Generate project for iOS (default macOS)"
-    echo "  --clean  Remove existing build directory before generating"
-    echo "  --open   Open the generated Xcode project"
+    echo "Usage: $0 [--ios-only] [--mac-only] [--clean] [--open]"
+    echo "  --ios-only Generate project only for iOS"
+    echo "  --mac-only Generate project only for macOS"
+    echo "  --clean    Remove existing build directory before generating"
+    echo "  --open     Open the generated Xcode project"
 }
 
 for arg in "$@"; do
     case $arg in
-        --ios)
-            IOS=true
+        --ios-only)
+            IOS_ONLY=true
+            ;;
+        --mac-only)
+            MAC_ONLY=true
             ;;
         --clean)
             CLEAN=true
@@ -46,12 +51,17 @@ fi
 mkdir -p build
 cd build
 
-if $IOS; then
-    echo "Configuring for iOS..."
-    cmake -G Xcode -DBUILD_FOR_IOS=ON ..
+cmake_args="-G Xcode"
+
+if $IOS_ONLY; then
+    echo "Configuring for iOS only..."
+    cmake $cmake_args -DBUILD_IOS_ONLY=ON ..
+elif $MAC_ONLY; then
+    echo "Configuring for macOS only..."
+    cmake $cmake_args -DBUILD_MAC_ONLY=ON ..
 else
-    echo "Configuring for macOS..."
-    cmake -G Xcode ..
+    echo "Configuring for macOS and iOS..."
+    cmake $cmake_args ..
 fi
 
 if [ $? -eq 0 ]; then
@@ -63,4 +73,6 @@ else
     echo "❌ Build setup failed!"
     exit 1
 fi
+
+
 


### PR DESCRIPTION
## Summary
- build both macOS and iOS apps in CMake
- add `Shaders` target for compiling Metal shaders
- update build scripts for the new behaviour
- document the new workflow in README and docs
- make shader compilation script support both platforms by default

## Testing
- `./scripts/check_structure.sh`
- `./scripts/compile_shaders.sh` *(fails: `xcrun` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685531850d348332a482d371e02eb150