### PR TITLE
Fix math header includes and namespace

### DIFF
--- a/include/FinalStorm/Core/Math.h
+++ b/include/FinalStorm/Core/Math.h
@@ -9,6 +9,7 @@
 
 #include <simd/simd.h>
 #include <cmath>
+#include "MathTypes.h"
 
 namespace FinalStorm {
 
@@ -51,6 +52,8 @@ private:
     float4x4 m_projectionMatrix;
 };
 
+namespace Math {
+
 // Math utilities
 float4x4 matrix_perspective_right_hand(float fovyRadians, float aspect, float nearZ, float farZ);
 float4x4 matrix_look_at_right_hand(float3 eye, float3 center, float3 up);
@@ -77,5 +80,16 @@ inline float4 make_float4(float x, float y, float z, float w) {
 inline float4 make_float4(float v) {
     return simd_make_float4(v, v, v, v);
 }
+
+// Simple helper to create a quaternion from angle and axis in radians.
+inline quat quaternion(float angle, const float3& axis) {
+#ifdef __APPLE__
+    return simd_quaternion(angle, axis);
+#else
+    return glm::angleAxis(angle, axis);
+#endif
+}
+
+} // namespace Math
 
 } // namespace FinalStorm

--- a/src/Core/Math/Math.h
+++ b/src/Core/Math/Math.h
@@ -9,6 +9,7 @@
 
 #include <simd/simd.h>
 #include <cmath>
+#include "Core/Math/MathTypes.h"
 
 namespace FinalStorm {
 
@@ -51,6 +52,8 @@ private:
     float4x4 m_projectionMatrix;
 };
 
+namespace Math {
+
 // Math utilities
 float4x4 matrix_perspective_right_hand(float fovyRadians, float aspect, float nearZ, float farZ);
 float4x4 matrix_look_at_right_hand(float3 eye, float3 center, float3 up);
@@ -86,5 +89,7 @@ inline quat quaternion(float angle, const float3& axis) {
     return glm::angleAxis(angle, axis);
 #endif
 }
+
+} // namespace Math
 
 } // namespace FinalStorm

--- a/src/Core/Math/MathTypes.h
+++ b/src/Core/Math/MathTypes.h
@@ -110,7 +110,7 @@
             
             rot.columns[3] = simd_make_float4(0.0f, 0.0f, 0.0f, 1.0f);
             
-            return m * rot;
+            return simd_mul(m, rot);
         }
         
         inline mat4 lookAt(const vec3& eye, const vec3& center, const vec3& up) {


### PR DESCRIPTION
## Summary
- include `MathTypes.h` in math headers
- wrap math utilities in a new `Math` namespace
- use `simd_mul` for matrix rotation on Apple

## Testing
- `./scripts/check_structure.sh`
- `./scripts/compile_shaders.sh` *(fails: metal compiler missing)*

------
https://chatgpt.com/codex/tasks/task_e_68556a7ba4ac83329c8f99b4f30bf1d9