### PR TITLE
Fix ParticleEmitter base class

### DIFF
--- a/src/Services/Components/ParticleEmitter.h
+++ b/src/Services/Components/ParticleEmitter.h
@@ -1,10 +1,10 @@
 #pragma once
-#include "World/Entity.h"
+#include "Scene/SceneNode.h"
 #include <glm/glm.hpp>
 
 namespace FinalStorm {
 
-class ParticleEmitter : public Entity {
+class ParticleEmitter : public SceneNode {
 public:
     enum class Shape {
         POINT,
@@ -36,7 +36,7 @@ public:
     
     void burst(int count);
     void setEmitRate(float rate);
-    void setEmitPosition(const glm::vec3& pos) { transform.position = pos; }
+    void setEmitPosition(const glm::vec3& pos) { setPosition(pos); }
     void setEmitShape(Shape shape) { m_config.emitShape = shape; }
     void setParticleColor(const glm::vec4& color) { m_config.startColor = color; }
     void setParticleLifetime(float lifetime) { m_config.particleLifetime = lifetime; }


### PR DESCRIPTION
## Summary
- make `ParticleEmitter` derive from `SceneNode`
- update inline `setEmitPosition`

## Testing
- `./scripts/check_structure.sh`
- `./scripts/compile_shaders.sh` *(fails: `xcrun` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565c608e2083328eca6cb18b76af99