### PR TITLE
Implement EnvironmentController features

### DIFF
--- a/src/Environment/EnvironmentController.cpp
+++ b/src/Environment/EnvironmentController.cpp
@@ -10,8 +10,18 @@ namespace FinalStorm {
 
 EnvironmentController::EnvironmentController()
     : SceneNode("Environment")
+    , m_ambientParticles(false)
+    , m_quantumFluctuations(0.0f)
+    , m_energyLevel(0.0f)
+    , m_harmonyLevel(0.0f)
     , systemHealth(1.0f)
-    , timeOfDay(0.5f) {
+    , timeOfDay(0.5f)
+    , skyColor(0.2f, 0.4f, 0.6f, 1.0f) {
+    m_state.skyboxTint = float3(0.0f);
+    m_state.ambientParticleRate = 0.0f;
+    m_state.groundPulse = 1.0f;
+    m_state.energyLevel = 0.0f;
+    m_state.harmonyLevel = 0.0f;
 }
 
 EnvironmentController::~EnvironmentController() = default;
@@ -41,6 +51,50 @@ void EnvironmentController::onRender(RenderContext& context) {
     context.popTransform();
 }
 
+void EnvironmentController::setSkyboxTheme(const std::string& theme) {
+    m_skyboxTheme = theme;
+    if (theme == "quantum_void") {
+        m_state.skyboxTint = float3(0.1f, 0.0f, 0.2f);
+    } else if (theme == "sunrise") {
+        m_state.skyboxTint = float3(0.6f, 0.3f, 0.2f);
+    } else {
+        m_state.skyboxTint = float3(0.0f);
+    }
+}
+
+void EnvironmentController::setGroundGridStyle(const std::string& style) {
+    m_groundGridStyle = style;
+    m_state.groundPulse = (style == "hexagonal") ? 1.5f : 1.0f;
+}
+
+void EnvironmentController::setAmbientParticles(bool enabled) {
+    m_ambientParticles = enabled;
+    m_state.ambientParticleRate = enabled ? 20.0f : 0.0f;
+}
+
+void EnvironmentController::setQuantumFluctuations(float amount) {
+    m_quantumFluctuations = amount;
+}
+
+void EnvironmentController::setEnergyLevel(float level) {
+    m_energyLevel = Math::clamp(level, 0.0f, 1.0f);
+    m_state.energyLevel = m_energyLevel;
+}
+
+void EnvironmentController::setHarmonyLevel(float level) {
+    m_harmonyLevel = Math::clamp(level, 0.0f, 1.0f);
+    m_state.harmonyLevel = m_harmonyLevel;
+}
+
+void EnvironmentController::updateFromHealth(float healthScore) {
+    float h = Math::clamp(healthScore, 0.0f, 1.0f);
+    setEnergyLevel(h);
+    setHarmonyLevel(h);
+    setAmbientParticles(h > 0.3f);
+    systemHealth = h;
+    updateSkyColor();
+}
+
 void EnvironmentController::setSystemHealth(float health) {
     systemHealth = Math::clamp(health, 0.0f, 1.0f);
 }
@@ -56,7 +110,7 @@ void EnvironmentController::updateSkyColor() {
     float3 unhealthyTint(0.3f, 0.0f, 0.0f);
     float3 tint = healthyTint * systemHealth + unhealthyTint * (1.0f - systemHealth);
     
-    skyColor = float4(baseColor + tint, 1.0f);
+    skyColor = float4(baseColor + tint + m_state.skyboxTint, 1.0f);
 }
 
 } // namespace FinalStorm

--- a/src/Environment/EnvironmentController.h
+++ b/src/Environment/EnvironmentController.h
@@ -1,26 +1,56 @@
 #pragma once
 
 #include "Core/Math/Math.h"
+#include "Scene/SceneNode.h"
+#include <string>
 
 namespace FinalStorm {
+
+class RenderContext;
 
 struct EnvironmentState {
     float3 skyboxTint;
     float ambientParticleRate;
     float groundPulse;
+    float energyLevel;
+    float harmonyLevel;
 };
 
-class EnvironmentController {
+class EnvironmentController : public SceneNode {
 public:
     EnvironmentController();
+    ~EnvironmentController() override;
 
     // Update environment parameters from a normalized health score [0,1]
     void updateFromHealth(float healthScore);
 
     const EnvironmentState& getState() const { return m_state; }
 
+    // Environment customization
+    void setSkyboxTheme(const std::string& theme);
+    void setGroundGridStyle(const std::string& style);
+    void setAmbientParticles(bool enabled);
+    void setQuantumFluctuations(float amount);
+    void setEnergyLevel(float level);
+    void setHarmonyLevel(float level);
+
 private:
     EnvironmentState m_state;
+    std::string m_skyboxTheme;
+    std::string m_groundGridStyle;
+    bool m_ambientParticles = false;
+    float m_quantumFluctuations = 0.0f;
+    float m_energyLevel = 0.0f;
+    float m_harmonyLevel = 0.0f;
+    float systemHealth;
+    float timeOfDay;
+    float4 skyColor;
+
+    void updateSkyColor();
+
+protected:
+    void onUpdate(float deltaTime) override;
+    void onRender(RenderContext& context) override;
 };
 
 } // namespace FinalStorm


### PR DESCRIPTION
## Summary
- expand `EnvironmentController` to inherit from `SceneNode`
- add customization APIs for skybox and grid
- store new environment values and expose them through `EnvironmentState`

## Testing
- `scripts/check_structure.sh`

------
https://chatgpt.com/codex/tasks/task_e_685664d37e5c8332a2606a96653cc083