### PR TITLE
Fix FirstScene performance monitor include

### DIFF
--- a/src/Scene/Scenes/FirstScene.h
+++ b/src/Scene/Scenes/FirstScene.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 #include <functional>
+#include <chrono>
 
 namespace FinalStorm {
 


### PR DESCRIPTION
## Summary
- add missing `<chrono>` include for the performance monitor types in `FirstScene.h`

## Testing
- `bash scripts/check_structure.sh`

------
https://chatgpt.com/codex/tasks/task_e_68567e4500d08332b8f2c69d2124fd40