### PR TITLE
Add scene sources to CORE_SOURCES list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ set(CORE_SOURCES
     src/Services/Components/ConnectionBeamRendering.cpp
     src/Services/Components/BeamMesh.cpp
     src/Services/Components/EnergyRing.cpp
+    src/Scene/Scenes/FirstScene.cpp
+    src/Scene/Scenes/CentralNexus.cpp
+    src/Scene/Scenes/ServiceRing.cpp
+    src/Scene/Scenes/InteractiveGuide.cpp
+    src/Scene/Scenes/WelcomeSequence.cpp
 )
 
 set(METAL_SOURCES


### PR DESCRIPTION
## Summary
- include missing scene implementations in `CORE_SOURCES`
- run project setup script

## Testing
- `./scripts/build_setup.sh` *(fails: Could not create named generator Xcode)*

------
https://chatgpt.com/codex/tasks/task_e_6856a6d11cf48332bfece2be0bd15f74