### PR TITLE
Remove duplicate FirstSceneConfig definition

### DIFF
--- a/src/Scene/SceneLoader.cpp
+++ b/src/Scene/SceneLoader.cpp
@@ -50,13 +50,13 @@ void SceneLoader::loadScene(const std::string& sceneName) {
 }
 
 void SceneLoader::loadFirstScene() {
-    // Load configuration
-    FirstSceneConfig config = FirstSceneConfig::loadFromPreferences();
-    
+    // Configuration can be loaded from preferences in the future
+    FirstSceneConfig config{};
+
     // Create the first scene with config
     auto createFirstScene = [config]() -> std::unique_ptr<Scene> {
         auto scene = std::make_unique<FirstScene>();
-        
+
         // Apply configuration
         // TODO: Add config setters to FirstScene
         

--- a/src/Scene/SceneLoader.h
+++ b/src/Scene/SceneLoader.h
@@ -114,32 +114,4 @@ namespace FinalStorm {
         void loadShaders(const std::string& sceneName);
     };
 
-    /**
-     * FirstSceneConfig - Configuration for the first scene
-     */
-    struct FirstSceneConfig {
-        // Visual settings
-        bool showWelcomeSequence = true;
-        float nexusScale = 1.0f;
-        float serviceRingRadius = 12.0f;
-        
-        // Environment settings
-        glm::vec3 nebulaPrimaryColor = glm::vec3(0.1f, 0.2f, 0.4f);
-        glm::vec3 nebulaSecondaryColor = glm::vec3(0.4f, 0.1f, 0.3f);
-        float nebulaDensity = 0.7f;
-        
-        // Service settings
-        bool autoDiscoverServices = true;
-        float serviceUpdateInterval = 1.0f;
-        
-        // Camera settings
-        glm::vec3 defaultCameraPosition = glm::vec3(15, 10, 15);
-        glm::vec3 defaultCameraLookAt = glm::vec3(0, 0, 0);
-        float defaultCameraFOV = 60.0f;
-        
-        // User preferences
-        static FirstSceneConfig loadFromPreferences();
-        void saveToPreferences() const;
-    };
-
 } // namespace FinalStorm


### PR DESCRIPTION
## Summary
- keep `FirstSceneConfig` only in `FirstScene.h`
- drop duplicate struct from `SceneLoader.h`
- reference the config without loading preferences yet

## Testing
- `./scripts/check_structure.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856aacc9f0883328802c306422510fe